### PR TITLE
String literals: remove invalid escape sequences.

### DIFF
--- a/src/pyRdfa/rdfs/cache.py
+++ b/src/pyRdfa/rdfs/cache.py
@@ -18,7 +18,7 @@ from ..utils import create_file_name
 from . import VocabCachingInfo
 
 # Regular expression object for a general XML application media type
-xml_application_media_type = re.compile("application/[a-zA-Z0-9]+\+xml")
+xml_application_media_type = re.compile(r"application/[a-zA-Z0-9]+\+xml")
 
 #===========================================================================================
 

--- a/src/pyRdfa/termorcurie.py
+++ b/src/pyRdfa/termorcurie.py
@@ -58,7 +58,7 @@ ncname   = re.compile("^[A-Za-z][A-Za-z0-9._-]*$")
 termname = re.compile("^[A-Za-z]([A-Za-z0-9._-]|/)*$")
 
 # Regular expression object for a general XML application media type
-xml_application_media_type = re.compile("application/[a-zA-Z0-9]+\+xml")
+xml_application_media_type = re.compile(r"application/[a-zA-Z0-9]+\+xml")
 
 XHTML_PREFIX = "xhv"
 XHTML_URI    = "http://www.w3.org/1999/xhtml/vocab#"

--- a/src/pyRdfa/utils.py
+++ b/src/pyRdfa/utils.py
@@ -128,7 +128,7 @@ class URIOpener:
 
 # 'safe' characters for the URI quoting, ie, characters that can safely stay as they are. Other 
 # special characters are converted to their %.. equivalents for namespace prefixes
-_unquotedChars = ':/\?=#~'
+_unquotedChars = r':/\?=#~'
 _warnChars = [' ','\n','\r','\t']
 
 def quote_URI(uri, options=None):


### PR DESCRIPTION
For cases where:

* A string literal is declared in the source code.
* The literal appears to contain an escape sequence (indicated by the `\` character).
* But the escape sequence is not valid (not one of `\t`, `\r`, `\n`, or an escaped quote, for example).
* And other valid escape sequences are _not_ present.

...translate the string into [raw-format notation](https://docs.python.org/3/howto/regex.html#the-backslash-plague).

This should prevent `SyntaxWarnings` due to invalid escape sequences when using this package in Python 3.12 and beyond.

The cases here were found in the codebase using the following one-time utility command:

```sh
# recursively grep the source for non-raw strings that could contain invalid escape sequences
$ grep -r "[^r]['\"].*[^\][\][^trn\]" src
```

Note: this is neither an entirely precise nor entirely comprehensive search.

Some local testing to confirm the equivalence of the results, using Python 3.11:

```pyi
Python 3.11.8 (main, Feb  7 2024, 21:52:08) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> "application/[a-zA-Z0-9]+\+xml" == r"application/[a-zA-Z0-9]+\+xml"
True
>>> "application/[a-zA-Z0-9]+\+xml" == r"application/[a-zA-Z0-9]+\+xml"
True
>>> ':/\?=#~' == r':/\?=#~'
True
```

Resolves #4.