### PR TITLE
new version 3.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > **Note:** since I retired a few months ago I do not really maintain this package any more. I would be more than happy if an interested party was interested to take over. In the meantime, I have "archived" the repository to clearly signal that there is no maintenance. I would be happy to unarchive it and transfer ownership if someone is interested.    
 > [@iherman](https://github.com/iherman)
 
-> **This new version 3.6.4 is now built and maintained on [prrvchr.github.io/pyrdfa3][1]**
+> **This new version 3.6.5 is now built and maintained on [prrvchr.github.io/pyrdfa3][1]**
 
 The package can be installed from [PyPI][2] with command:  
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyRdfa3"
-version = "3.6.4"
+version = "3.6.5"
 authors = [
   { name="Ivan Herman & prrvchr", email="prrvchr@gmail.com" },
 ]

--- a/src/pyRdfa/extras/httpheader.py
+++ b/src/pyRdfa/extras/httpheader.py
@@ -344,7 +344,7 @@ def parse_quoted_string(s, start=0):
     """Parses a quoted string.
 
     Returns a tuple (string, chars_consumed).  The quote marks will
-    have been removed and all \-escapes will have been replaced with
+    have been removed and all \\-escapes will have been replaced with
     the characters they represent.
 
     """
@@ -356,7 +356,7 @@ def parse_token_or_quoted_string(s, start=0, allow_quoted=True, allow_token=True
 
     's' is the string to parse, while start is the position within the
     string where parsing should begin.  It will returns a tuple
-    (token, chars_consumed), with all \-escapes and quotation already
+    (token, chars_consumed), with all \\-escapes and quotation already
     processed.
 
     Syntax is according to BNF rules in RFC 2161 section 2.2,
@@ -522,7 +522,7 @@ def parse_comment(s, start=0):
     nested comments will still have their parentheses and whitespace
     left intact.
 
-    All \-escaped quoted pairs will have been replaced with the actual
+    All \\-escaped quoted pairs will have been replaced with the actual
     characters they represent, even within the inner nested comments.
 
     You should note that only a few HTTP headers, such as User-Agent

--- a/src/pyRdfa3.egg-info/PKG-INFO
+++ b/src/pyRdfa3.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: pyRdfa3
-Version: 3.6.4
+Version: 3.6.5
 Summary: pyRdfa distiller/parser library
 Author-email: Ivan Herman & prrvchr <prrvchr@gmail.com>
 Project-URL: Homepage, https://prrvchr.github.io/pyrdfa3/
@@ -21,7 +21,7 @@ Requires-Dist: html5lib>=1.1
 > **Note:** since I retired a few months ago I do not really maintain this package any more. I would be more than happy if an interested party was interested to take over. In the meantime, I have "archived" the repository to clearly signal that there is no maintenance. I would be happy to unarchive it and transfer ownership if someone is interested.    
 > [@iherman](https://github.com/iherman)
 
-> **This new version 3.6.4 is now built and maintained on [prrvchr.github.io/pyrdfa3][1]**
+> **This new version 3.6.5 is now built and maintained on [prrvchr.github.io/pyrdfa3][1]**
 
 The package can be installed from [PyPI][2] with command:  
 


### PR DESCRIPTION
Modified the file: `src/pyRdfa/extras/httpheader.py`
to stop warnings from appearing regarding invalid escape sequences.