### PR TITLE
[WIP] Address Python 3.13 str decoding error

### DIFF
--- a/src/pyRdfa/__init__.py
+++ b/src/pyRdfa/__init__.py
@@ -688,8 +688,7 @@ class pyRdfa:
         for name in names:
             self.graph_from_source(name, graph, rdfOutput)
 
-        # Stupid difference between python2 and python3...
-        return str(graph.serialize(format=outputFormat), encoding='utf-8')
+        return graph.serialize(format=outputFormat)
 
 
     def rdf_from_source(self, name, outputFormat = "turtle", rdfOutput = False):
@@ -929,4 +928,3 @@ def processURI(uri, outputFormat, form={}):
         retval +="</body>\n"
         retval +="</html>\n"
         return retval
-


### PR DESCRIPTION
I don't necessarily think this should be merged because I don't know the historical reasons for having the decode here so the change might break legacy code.
However, in Python 3.13, we get the error
```
TypeError: decoding str is not supported
```
This change fixes this error